### PR TITLE
Update URL for probeGoogleFontsAPI

### DIFF
--- a/modules/core/GoogleFontsAPI/probeGoogleFontsApi.ts
+++ b/modules/core/GoogleFontsAPI/probeGoogleFontsApi.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-export const GOOGLE_FONT_API_URL = 'https://google-webfonts-helper.herokuapp.com/api/fonts';
+export const GOOGLE_FONT_API_URL = 'https://gwfh.mranftl.com/api/fonts';
 
 /**
  * Check


### PR DESCRIPTION
The old url  (https://google-webfonts-helper.herokuapp.com) was shut down on 27th of November.
Based on their https://github.com/majodev/google-webfonts-helper this is new the url: https://gwfh.mranftl.com/api/fonts